### PR TITLE
Add signing plugin

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.gradle.plugin.publish)
     alias(libs.plugins.gradle.test.retry)
     alias(libs.plugins.ktfmt)
+    signing
 }
 
 gradlePlugin {
@@ -24,6 +25,8 @@ gradlePlugin {
         }
     }
 }
+
+signing { setRequired { gradle.taskGraph.hasTask(":plugin:publishPlugins") } }
 
 ktfmt {
     kotlinLangStyle()


### PR DESCRIPTION
When this plugin is added we just have to set some properties with the signing key and password and it will sign the plugin when publishing: https://docs.gradle.org/current/userguide/signing_plugin.html#signing_plugin

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/rust-android-gradle/7)
<!-- Reviewable:end -->
