### PR TITLE
Fix regression of sourceset registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Marked plugin as CC-compatible
+- Fixed a bug sourcesets sometimes would not be picked up
 
 # 0.10.0
 

--- a/plugin/src/main/kotlin/net/mullvad/androidrust/RustAndroidPlugin.kt
+++ b/plugin/src/main/kotlin/net/mullvad/androidrust/RustAndroidPlugin.kt
@@ -4,7 +4,8 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.AndroidComponents
-import com.android.build.gradle.*
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryPlugin
 import java.io.File
 import java.util.Properties
 import org.gradle.api.DefaultTask
@@ -170,6 +171,15 @@ open class RustAndroidPlugin : Plugin<Project> {
         with(project) {
             val cargoExtension = extensions.create("cargo", CargoExtension::class.java)
 
+            // Register jniLibs source directories eagerly (before AGP finalizes source sets)
+            // so that directories.add() works correctly.
+            plugins.all {
+                when (it) {
+                    is AppPlugin -> registerJniSourceDirs<ApplicationExtension>()
+                    is LibraryPlugin -> registerJniSourceDirs<LibraryExtension>()
+                }
+            }
+
             afterEvaluate {
                 plugins.all {
                     when (it) {
@@ -178,6 +188,14 @@ open class RustAndroidPlugin : Plugin<Project> {
                     }
                 }
             }
+        }
+    }
+
+    private inline fun <reified T : CommonExtension> Project.registerJniSourceDirs() {
+        val buildDir = layout.buildDirectory.get().asFile
+        extensions[T::class].apply {
+            sourceSets.getByName("main").jniLibs.directories.add("$buildDir/rustJniLibs/android")
+            sourceSets.getByName("test").resources.directories.add("$buildDir/rustJniLibs/desktop")
         }
     }
 
@@ -228,12 +246,6 @@ open class RustAndroidPlugin : Plugin<Project> {
             cargoExtension.targets!!.toSet().minus(cargoExtension.apiLevels.keys)
         if (missingApiLevelTargets.isNotEmpty()) {
             throw GradleException("`apiLevels` missing entries for: $missingApiLevelTargets")
-        }
-
-        extensions[T::class].apply {
-            val buildDir by layout.buildDirectory
-            sourceSets.getByName("main").jniLibs.directories.add("$buildDir/rustJniLibs/android")
-            sourceSets.getByName("test").resources.directories.add("$buildDir/rustJniLibs/desktop")
         }
 
         // Determine the NDK version, if present


### PR DESCRIPTION
In certain configurations the AGP 9+ would not pick up the sourceset due to it not being added before AGP was ran. `directories.add()` api does not add the newly added source set to the `lateAdditionsDelegates` requiring us to register the sourcesets earlier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/rust-android-gradle/16)
<!-- Reviewable:end -->
