### PR TITLE
Compile only on Gradle API and Kotlin stdlib

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -69,7 +69,7 @@ val localRepo = file("${layout.buildDirectory.get()}/local-repo")
 publishing { repositories { maven(localRepo) } }
 
 dependencies {
-    implementation(gradleApi())
+    compileOnly(gradleApi())
     implementation(libs.kotlinx.serialization.json)
     compileOnly(libs.android.gradle.plugin)
 

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,0 +1,3 @@
+# Omit automatic compile dependency on kotlin-stdlib.
+# https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
They should be depended on by `compileOnly` instead of `implementation`.

```diff
diff --color=auto -r old/plugin/0.10.1/plugin-0.10.1.module new/plugin/0.10.1/plugin-0.10.1.module
28,36d27
<       "dependencies": [
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.3.21"
<           }
<         }
<       ],
66,72d56
<           }
<         },
<         {
<           "group": "org.jetbrains.kotlin",
<           "module": "kotlin-stdlib",
<           "version": {
<             "requires": "2.3.21"
diff --color=auto -r old/plugin/0.10.1/plugin-0.10.1.pom new/plugin/0.10.1/plugin-0.10.1.pom
14,19d13
<       <groupId>org.jetbrains.kotlin</groupId>
<       <artifactId>kotlin-stdlib</artifactId>
<       <version>2.3.21</version>
<       <scope>compile</scope>
<     </dependency>
<     <dependency>
diff --color=auto -r old/plugin/maven-metadata-local.xml new/plugin/maven-metadata-local.xml
11c11
<     <lastUpdated>20260513100445</lastUpdated>
---
>     <lastUpdated>20260513100638</lastUpdated>
diff --color=auto -r old/rust-android/net.mullvad.rust-android.gradle.plugin/maven-metadata-local.xml new/rust-android/net.mullvad.rust-android.gradle.plugin/maven-metadata-local.xml
11c11
<     <lastUpdated>20260513100438</lastUpdated>
---
>     <lastUpdated>20260513100637</lastUpdated>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/rust-android-gradle/20)
<!-- Reviewable:end -->
