### PR TITLE
Fix cache annotation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,17 @@ jobs:
         run: |
           ./gradlew ktfmtCheck
 
+  validate_plugin:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE for the job.
+      - uses: actions/checkout@v6
+
+      - name: Check formatting
+        run: |
+          ./gradlew :plugin:validatePlugins
+
   generate_versions:
     runs-on: ubuntu-latest
 

--- a/plugin/src/main/kotlin/net/mullvad/androidrust/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/net/mullvad/androidrust/CargoBuildTask.kt
@@ -13,7 +13,14 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
+import org.gradle.work.DisableCachingByDefault
 
+// Gradle task output caching is disabled for this task.
+// `cargo build` reads additional Rust-side inputs that are not fully declared here
+// (for example sources, Cargo.toml, Cargo.lock, build.rs etc.), so identical declared task inputs
+// could still produce different outputs.
+
+@DisableCachingByDefault(because = "Cargo inputs are not fully modeled as task inputs")
 abstract class CargoBuildTask : DefaultTask() {
     @Input val toolchain = property<Toolchain>()
 


### PR DESCRIPTION
As reported by @Goooler in #21, `:plugin:validatePlugins` task errors out. This PR addresses it by adding the cache annotation, see [this discussion](ttps://github.com/mullvad/rust-android-gradle/pull/21#discussion_r3266151192) for more context. To prevent this from happening moving forth it also adds a new CI job to run `:plugin:validatePlugin`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/rust-android-gradle/22)
<!-- Reviewable:end -->
